### PR TITLE
앱 이름으로 검색 이후 애플리케이션 선택 시 비정상 종료

### DIFF
--- a/app/src/main/java/com/roomedia/dawn_down_alarm/presentation/view/adapter/AppListAdapter.kt
+++ b/app/src/main/java/com/roomedia/dawn_down_alarm/presentation/view/adapter/AppListAdapter.kt
@@ -81,7 +81,7 @@ class AppListAdapter(private val fragment: AppListFragment) : ListAdapter<AppAnd
     }
 
     fun showBottomSheetDialog(view: View) {
-        EditKeywordBottomSheetDialogFragment(getItem(view.id)) {
+        EditKeywordBottomSheetDialogFragment(view.tag as String) {
             notifyItemChanged(view.id)
         }.show(fragment.childFragmentManager, null)
     }
@@ -94,8 +94,6 @@ class AppListAdapter(private val fragment: AppListFragment) : ListAdapter<AppAnd
             val (app, keywords) = appAndKeywords
             binding.app = app!!
             binding.keywords = keywords
-            binding.root.id = position
-
             binding.root.setOnLongClickListener {
                 val context = binding.root.context
                 val isEnabled = if (app.isEnabled) R.string.disable else R.string.enable

--- a/app/src/main/res/layout/item_app_list.xml
+++ b/app/src/main/res/layout/item_app_list.xml
@@ -23,6 +23,7 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
+        android:tag="@{app.packageName}"
         android:onClick="@{adapter::showBottomSheetDialog}">
 
         <ImageView


### PR DESCRIPTION
현재 ViewHolder Bind 시 position을 view id로 등록하여 이를 토대로 데이터를 획득, bottom sheet fragment에 전달하고 있으나 검색, 필터링 기능의 추가로 viewholder bind 시 위치와 현재 앱의 위치가 달라져 엉뚱한 앱을 표시하거나 앱이 crush 되는 경우가 발생하고 있음

현재:
position -> view id -> getItem 식으로 간접적으로 전해지던 데이터를 획득하여 Bottom Sheet Fragment의 생성자로 전달

변경:
primary key 전달 -> Bottom Sheet Fragment의 viewModel에서 쿼리하는 방식으로 전환